### PR TITLE
feat(pwa): dual install buttons (Android + iOS guide)Feat/pwa dual install

### DIFF
--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -38,17 +38,29 @@ export default function LanguageSwitcher({ language, setLanguage }: LanguageSwit
         >
           English
         </button>
-        {/* CTA de instalación */}
+        {/* CTA de instalación (Android) */}
         <button
           id="install-app-cta"
           className={cn(
             'btn-install rounded-full px-5 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
             'text-muted-foreground hover:bg-accent'
           )}
-          onClick={() => (window as any).installApp()}
-          title="Instalar app"
+          onClick={() => (window as any).installAndroid?.()}
+          title="Instalar en Android"
         >
           ▼ Install App Android
+        </button>
+        {/* CTA iOS/Apple (nuevo) */}
+        <button
+          id="install-ios-cta"
+          className={cn(
+            'btn-install rounded-full px-5 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            'text-muted-foreground hover:bg-accent'
+          )}
+          onClick={() => (window as any).showIosGuide?.()}
+          title="Instalar en iOS / Apple"
+        >
+          ▼ Install App iOS/Apple
         </button>
       </div>
     </div>

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -48,7 +48,7 @@ export default function LanguageSwitcher({ language, setLanguage }: LanguageSwit
           onClick={() => (window as any).installApp()}
           title="Instalar app"
         >
-          Instalar app
+          ▼ Install App Android
         </button>
       </div>
     </div>

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -48,7 +48,7 @@ export default function LanguageSwitcher({ language, setLanguage }: LanguageSwit
           onClick={() => (window as any).installAndroid?.()}
           title="Instalar en Android"
         >
-          ▼ Install App Android
+          ▼Install App Android
         </button>
         {/* CTA iOS/Apple (nuevo) */}
         <button
@@ -60,7 +60,7 @@ export default function LanguageSwitcher({ language, setLanguage }: LanguageSwit
           onClick={() => (window as any).showIosGuide?.()}
           title="Instalar en iOS / Apple"
         >
-          ▼ Install App iOS/Apple
+          ▼Install App iOS/Apple
         </button>
       </div>
     </div>


### PR DESCRIPTION
- Cambia CTA Android a “▼ Install App Android”
- Agrega CTA “▼ Install App iOS/Apple” con guía compacta
- Popover iOS sin oscurecer la app
- Mantiene manifest + SW + safe-areas